### PR TITLE
Added the missing user name field to allow the application to run.

### DIFF
--- a/db/migrate/20141116123902_devise_create_users.rb
+++ b/db/migrate/20141116123902_devise_create_users.rb
@@ -2,6 +2,7 @@ class DeviseCreateUsers < ActiveRecord::Migration
   def change
     create_table(:users) do |t|
       ## Database authenticatable
+      t.string :name,              null: false, default: ""
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,9 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150102124822) do
+ActiveRecord::Schema.define(version: 20141116123907) do
 
   create_table "users", force: :cascade do |t|
+    t.string   "name",                   default: "", null: false
     t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: "", null: false
     t.string   "reset_password_token"


### PR DESCRIPTION
After setting up and running the application, I've noticed that the `users` table were missing the `name` field, although it was referenced in the views and controllers.

I've updated the `devise_create_users` migration to add a name field and allow the app to function correctly.
